### PR TITLE
Added absent balances to CashFlowStatement

### DIFF
--- a/src/Reports/CashFlowStatement.php
+++ b/src/Reports/CashFlowStatement.php
@@ -99,6 +99,9 @@ class CashFlowStatement extends FinancialStatement
         $this->balances[self::NON_CURRENT_ASSETS] = 0;
         $this->balances[self::NON_CURRENT_LIABILITIES] = 0;
         $this->balances[self::EQUITY] = 0;
+        $this->balances[self::PROFIT] = 0;
+        $this->balances[self::START_CASH_BALANCE] = 0;
+        $this->balances[self::NET_CASH_FLOW] = 0;
 
         // Statement Results
         $this->results[self::OPERATIONS_CASH_FLOW] = 0;


### PR DESCRIPTION
CashFlowStatement didn't work without PROFIT, START_CASH_BALANCE, NET_CASH_FLOW initializations.